### PR TITLE
時刻選択の修正と初期位置の修正

### DIFF
--- a/src/app/features/map/components/container/map-container/map-container.component.ts
+++ b/src/app/features/map/components/container/map-container/map-container.component.ts
@@ -27,13 +27,15 @@ const MAP_CONTAINER_CONSTANTS = {
   /** 最小スケール */
   MIN_SCALE: 1.0,
   /** マックス移動制限の基本値 */
-  BASE_OFFSET_LIMIT: 500,
+  BASE_OFFSET_LIMIT: 1000,
   /** キャンバス幅に対するオフセット制限の比率 */
-  CANVAS_WIDTH_OFFSET_RATIO: 0.6,
+  CANVAS_WIDTH_OFFSET_RATIO: 1.2,
   /** キャンバス高さに対するオフセット制限の比率 */
-  CANVAS_HEIGHT_OFFSET_RATIO: 0.6,
+  CANVAS_HEIGHT_OFFSET_RATIO: 1.2,
   /** 現在地表示時のスケール */
-  CURRENT_LOCATION_SCALE: 100,
+  CURRENT_LOCATION_SCALE: 1000,
+  /** 日本表示時のスケール（現在地取得できない場合） */
+  JAPAN_LOCATION_SCALE: 50,
   /** 再試行の待機時間（ミリ秒） */
   RETRY_DELAY_MS: 100,
   /** 位置情報取得の高精度モード */
@@ -344,13 +346,14 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
 
     const currentScale = this.mapTransformSignal().scale;
     // スケールに応じて制限を調整（より大きいスケールではより大きい移動を許可）
+    // より広範囲な移動を可能にするために制限値を増加
     const maxOffsetX = Math.max(
       MAP_CONTAINER_CONSTANTS.BASE_OFFSET_LIMIT,
-      canvasWidth * MAP_CONTAINER_CONSTANTS.CANVAS_WIDTH_OFFSET_RATIO * currentScale
+      canvasWidth * MAP_CONTAINER_CONSTANTS.CANVAS_WIDTH_OFFSET_RATIO * currentScale * 2
     );
     const maxOffsetY = Math.max(
       MAP_CONTAINER_CONSTANTS.BASE_OFFSET_LIMIT,
-      canvasHeight * MAP_CONTAINER_CONSTANTS.CANVAS_HEIGHT_OFFSET_RATIO * currentScale
+      canvasHeight * MAP_CONTAINER_CONSTANTS.CANVAS_HEIGHT_OFFSET_RATIO * currentScale * 2
     );
 
     this.mapTransformSignal.update(transform => ({
@@ -359,10 +362,7 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
       maxOffsetY,
     }));
 
-    // キャンバス情報を更新
-    this.canvasInfoSignal.set({ width: canvasWidth, height: canvasHeight });
-
-    // キャンバス情報を更新
+    // キャンバス情報を更新（重複呼び出しを削除）
     this.canvasInfoSignal.set({ width: canvasWidth, height: canvasHeight });
   }
 
@@ -397,6 +397,58 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
   }
 
   /**
+   * 日本の中心位置を中心としたマップ表示を設定する
+   */
+  private setDefaultJapanPosition(): void {
+    // 日本のおおよその中心位置（本州中央部）
+    const japanLatitude = 36.2048;
+    const japanLongitude = 138.2529;
+
+    // マップデータが読み込まれるのを待つ
+    const waitForMapData = (): void => {
+      if (this.mapDataSignal()) {
+        // 保存されたキャンバス情報を使用
+        const canvasInfo = this.canvasInfoSignal();
+        if (canvasInfo.width <= 0 || canvasInfo.height <= 0) {
+          // キャンバス情報がまだ有効でない場合は少し待ってから再試行
+          setTimeout(waitForMapData, MAP_CONTAINER_CONSTANTS.RETRY_DELAY_MS);
+          return;
+        }
+
+        const canvasWidth = canvasInfo.width;
+        const canvasHeight = canvasInfo.height;
+
+        // 日本全体が見えるようにスケールを設定
+        const scale = MAP_CONTAINER_CONSTANTS.JAPAN_LOCATION_SCALE;
+
+        // 緯度経度を画面座標に変換
+        const pointX = japanLongitude * scale;
+        const pointY = (MAP_CONTAINER_CONSTANTS.LATITUDE_OFFSET - japanLatitude) * scale;
+
+        // 日本が画面中央に来るようオフセットを計算
+        const offsetX = canvasWidth / 2 - pointX;
+        const offsetY = canvasHeight / 2 - pointY;
+
+        this.mapTransformSignal.update(transform => ({
+          ...transform,
+          scale: scale,
+          offsetX: offsetX,
+          offsetY: offsetY,
+          minScale: MAP_CONTAINER_CONSTANTS.MIN_SCALE,
+        }));
+
+        // マップの再描画をトリガー
+        this.forceMapRedraw();
+      } else {
+        // マップデータがまだ読み込まれていない場合は少し待ってから再試行
+        setTimeout(waitForMapData, MAP_CONTAINER_CONSTANTS.RETRY_DELAY_MS);
+      }
+    };
+
+    waitForMapData();
+  }
+
+  /**
    * 現在の地理位置情報を取得する
    */
   private getCurrentLocation(): void {
@@ -426,7 +478,8 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
             default:
               console.warn('位置情報の取得中に未知のエラーが発生しました');
           }
-          // 位置情報が取得できない場合はデフォルト表示のままとする
+          // 位置情報が取得できない場合は日本の中心を表示
+          this.setDefaultJapanPosition();
         },
         // オプション：タイムアウトを10秒に設定、高精度モードを有効
         {
@@ -437,7 +490,8 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
       );
     } else {
       console.error('このブラウザでは位置情報がサポートされていません');
-      // Geolocationがサポートされていない場合はデフォルト表示
+      // Geolocationがサポートされていない場合は日本の中心を表示
+      this.setDefaultJapanPosition();
     }
   }
 

--- a/src/app/features/map/components/container/map-container/map-container.component.ts
+++ b/src/app/features/map/components/container/map-container/map-container.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnInit, computed, inject, signal } from '@angular/core';
+import { AfterViewInit, Component, OnInit, computed, effect, inject, signal } from '@angular/core';
 
 import { TrafficControlsContainerComponent } from '../../../../../features/jam/components/container/traffic-controls-container/traffic-controls-container.component';
 import { TrafficDataStore } from '../../../../../features/jam/stores/traffic-data.store';
@@ -93,6 +93,34 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
   protected readonly trafficDataLoading = this.trafficDataStore.loading;
   protected readonly trafficDataError = this.trafficDataStore.error;
   protected readonly selectedHour = this.trafficDataStore.selectedHour;
+
+  constructor() {
+    // 選択時刻が変化したら吹き出しの交通レベルも更新
+    effect(() => {
+      // 現在のポップアップ情報と選択された時間を取得
+      const popup = this.roadPopupSignal();
+      this.selectedHour(); // 明示的に selectedHour の変更を監視
+
+      // ポップアップが表示されていない場合は何もしない
+      if (!popup || !popup.properties) return;
+
+      // 道路IDを取得
+      const roadId = popup.properties['N12_005'] || popup.properties['id'];
+      if (!roadId) return;
+
+      // 現在の時間帯における道路の交通情報を取得
+      const roadTrafficInfo = this.roadTrafficInfo();
+      const info = roadTrafficInfo.find(info => {
+        const infoId = info.roadFeature.properties?.['N12_005'] || info.roadFeature.id;
+        return infoId === roadId;
+      });
+
+      // 交通情報が見つかり、かつ現在のポップアップの交通レベルと異なる場合のみ更新
+      if (info && popup.trafficLevel !== info.trafficLevel) {
+        this.roadPopupSignal.set({ ...popup, trafficLevel: info.trafficLevel });
+      }
+    });
+  }
 
   /**
    * キャンバス情報変更イベントを処理する

--- a/src/app/features/map/models/map-transform.model.ts
+++ b/src/app/features/map/models/map-transform.model.ts
@@ -83,19 +83,19 @@ export interface Point {
  */
 export const MAP_TRANSFORM_CONSTANTS = {
   /** 初期スケール値 */
-  INITIAL_SCALE: 1,
+  INITIAL_SCALE: 20,
   /** 初期X軸オフセット */
-  INITIAL_OFFSET_X: 0,
+  INITIAL_OFFSET_X: 500,
   /** 初期Y軸オフセット */
-  INITIAL_OFFSET_Y: 0,
+  INITIAL_OFFSET_Y: 30,
   /** 最小拡大率 */
   MIN_SCALE: 1.0,
   /** 最大拡大率 */
-  MAX_SCALE: 5000,
+  MAX_SCALE: 20000,
   /** X軸方向の最大オフセット初期値 */
-  INITIAL_MAX_OFFSET_X: 2000,
+  INITIAL_MAX_OFFSET_X: 10000,
   /** Y軸方向の最大オフセット初期値 */
-  INITIAL_MAX_OFFSET_Y: 1500,
+  INITIAL_MAX_OFFSET_Y: 10000,
 };
 
 /**


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
# 概要
時刻選択の修正と初期位置の修正

# 詳細
This pull request introduces enhancements to the `MapContainerComponent` and related constants to improve map interaction, default positioning, and traffic data synchronization. Key changes include the addition of a method for setting a default map position centered on Japan, adjustments to scaling and offset limits, and the introduction of reactive updates for traffic level popups.

### Enhancements to map positioning and scaling:
* [`src/app/features/map/components/container/map-container/map-container.component.ts`](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aR399-R450): Added a method `setDefaultJapanPosition` to center the map on Japan when location data is unavailable, and updated error handling to call this method in such cases. [[1]](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aR399-R450) [[2]](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aL401-R482) [[3]](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aL412-R494)
* [`src/app/features/map/models/map-transform.model.ts`](diffhunk://#diff-b9b7c48789c97c53f27b3710ef22624c0a4c6d9d72ff9bf96059e49a34e7227bL86-R98): Adjusted initial scale, offsets, and maximum scale/offset limits to allow for broader map interaction.

### Traffic data synchronization:
* [`src/app/features/map/components/container/map-container/map-container.component.ts`](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aR99-R126): Introduced a reactive `effect` in the constructor to update traffic level information in popups based on the selected hour.

### Code cleanup and improvements:
* [`src/app/features/map/components/container/map-container/map-container.component.ts`](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aL334-R365): Removed redundant canvas update calls and refined offset calculations for better map movement range. [[1]](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aL334-R365) [[2]](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aR349-R356)

### Constant adjustments:
* [`src/app/features/map/components/container/map-container/map-container.component.ts`](diffhunk://#diff-bbcf45655bc15804f07e8f66339aa89f5cbba3a6528eb26f930707ea3d53df2aL30-R38): Updated `MAP_CONTAINER_CONSTANTS` to refine scaling and offset ratios, and added a new constant for Japan's default scale.
# その他

<!-- I want to review in Japanese. -->
